### PR TITLE
Update get_cmaize.cmake

### DIFF
--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -30,7 +30,7 @@ function(get_cmaize)
     FetchContent_Declare(
         cmaize
         GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
-        GIT_TAG 1.0.0
+        GIT_TAG v1.0.1
     )
     FetchContent_MakeAvailable(cmaize)
 

--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -30,7 +30,7 @@ function(get_cmaize)
     FetchContent_Declare(
         cmaize
         GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
-        GIT_TAG 3cef972afa573c8d0c56a832341b8b20646f3d16
+        GIT_TAG 1.0.0
     )
     FetchContent_MakeAvailable(cmaize)
 


### PR DESCRIPTION
Bumps the version of CMaize to 1.0.0. I am in the process of locally checking that this doesn't break the stack.