### PR TITLE
Fixes linking error

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -66,11 +66,11 @@ endfunction()
 #    This function shouldn't be needed if CMaize#151 is tackled.
 #]]
 function(nwx_find_pybind11)
+    nwx_find_python()
+
     if(TARGET pybind11::embed OR TARGET pybind11_headers)
         return()
     endif()
-
-    nwx_find_python()
 
     cmaize_find_or_build_dependency(
         pybind11


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
#41 didn't look for Python if Pybind11 had already been found. For some reason it appears that 
Pybind11's targets can be in scope, but not Python's. This PR fixes that by searching for Python regardless of whether Pybind11 has already been found.

**TODOs**
None. R2g.
