### PR TITLE
patch for when pybind11 goes rouge

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -66,8 +66,6 @@ endfunction()
 #    This function shouldn't be needed if CMaize#151 is tackled.
 #]]
 function(nwx_find_pybind11)
-    nwx_find_python()
-
     if(TARGET pybind11::embed OR TARGET pybind11_headers)
         return()
     endif()
@@ -78,7 +76,7 @@ function(nwx_find_pybind11)
         BUILD_TARGET pybind11_headers
         FIND_TARGET pybind11::embed
         CMAKE_ARGS PYBIND11_INSTALL=ON
-                   PYBIND11_FINDPYTHON=OFF
+                   PYBIND11_FINDPYTHON=ON
     )
 endfunction()
 
@@ -115,6 +113,7 @@ function(nwx_add_pybind11_module npm_module_name)
     endif()
 
     nwx_find_pybind11()
+    nwx_find_python()
 
     set(_npm_py_target_name "py_${npm_module_name}")
     cmaize_add_library(


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
None

**Description**
Pybind11 tries to cover all bases of how one may look for Python, including using deprecated CMake modules. This PR reorders our module so Pybind11 gets first dibs at looking for Python. This allows us to avoid needing to replicate the logic for the deprecated module.

**TODOs**
None.
