### PR TITLE
Factorization of CMakeLists.txt

### DIFF
--- a/cmake/get_catch2.cmake
+++ b/cmake/get_catch2.cmake
@@ -1,0 +1,7 @@
+cmaize_find_or_build_dependency(
+    Catch2
+    URL github.com/catchorg/Catch2
+    BUILD_TARGET Catch2
+    FIND_TARGET Catch2::Catch2
+    VERSION v3.6.0
+)

--- a/cmake/get_chemcache.cmake
+++ b/cmake/get_chemcache.cmake
@@ -1,0 +1,8 @@
+cmaize_find_or_build_dependency(
+    chemcache 
+    URL github.com/NWChemEx/ChemCache
+    BUILD_TARGET chemcache
+    FIND_TARGET nwx::chemcache
+    CMAKE_ARGS BUILD_TESTING=OFF
+               BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
+)

--- a/cmake/get_exachem.cmake
+++ b/cmake/get_exachem.cmake
@@ -1,0 +1,8 @@
+cmaize_find_or_build_dependency(
+    exachem
+    URL github.com/ExaChem/exachem
+    VERSION main
+    BUILD_TARGET exachem
+    FIND_TARGET exachem::exachem
+    CMAKE_ARGS MODULES="DFT"
+)

--- a/cmake/get_gauxc.cmake
+++ b/cmake/get_gauxc.cmake
@@ -1,0 +1,8 @@
+cmaize_find_or_build_dependency(
+    gauxc
+    URL github.com/wavefunction91/GauXC
+    BUILD_TARGET gauxc
+    FIND_TARGET gauxc::gauxc
+    CMAKE_ARGS BUILD_TESTING=OFF 
+               GAUXC_ENABLE_HDF5=OFF
+)

--- a/cmake/get_libint2.cmake
+++ b/cmake/get_libint2.cmake
@@ -1,0 +1,7 @@
+cmaize_find_or_build_dependency(
+    Libint2
+    URL github.com/evaleev/libint
+    VERSION 2.7.2
+    BUILD_TARGET int2
+    FIND_TARGET Libint2::int2
+)

--- a/cmake/get_nwchemex.cmake
+++ b/cmake/get_nwchemex.cmake
@@ -1,0 +1,7 @@
+cmaize_find_or_build_dependency(
+    nwchemex
+    URL github.com/NWChemEx/NWChemEx
+    BUILD_TARGET nwchemex
+    FIND_TARGET nwx::nwchemex
+    CMAKE_ARGS BUILD_TESTING=OFF
+)   

--- a/cmake/get_simde.cmake
+++ b/cmake/get_simde.cmake
@@ -1,0 +1,8 @@
+cmaize_find_or_build_dependency(
+    simde
+    URL github.com/NWChemEx/SimDE
+    BUILD_TARGET simde
+    FIND_TARGET nwx::simde
+    CMAKE_ARGS BUILD_TESTING=OFF
+               BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
+)

--- a/cmake/get_tamm.cmake
+++ b/cmake/get_tamm.cmake
@@ -1,0 +1,8 @@
+cmaize_find_or_build_dependency(
+    tamm
+    URL github.com/NWChemEx-Project/TAMM
+    VERSION main
+    BUILD_TARGET tamm
+    FIND_TARGET tamm::tamm
+    CMAKE_ARGS MODULES="DFT"
+)


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
Most of our CMakeLists.txt still include some boilerplate for calling CMaize to get dependencies like SimDE or PluginPlay. This PR factors those out into `get_xxx.cmake` modules which can be included instead of duplicating the boilerplate (assuming the `CMakeLists.txt` pulls in the NWXCMake repo). This also makes it easier to add dependencies in a loop.

**TODOs**
R2g.
