### PR TITLE
Add drop-in fix for get_version_from_git.cmake

### DIFF
--- a/cmake/get_version_from_git.cmake
+++ b/cmake/get_version_from_git.cmake
@@ -28,7 +28,7 @@ include_guard()
 #    message("My project's version is: ${MY_PROJECT_VERSION}")
 #]]
 function(get_version_from_git _gvfg_result _gvfg_git_root)
-    # Just default the version to "0.1.0"
+    # Just default the version to "0.1.0" for now
     set(_gvfg_default_version "0.1.0")
     # Alternatively, if there is a project version already set, we could grab
     # that to use as the default. However, this would require the
@@ -36,13 +36,10 @@ function(get_version_from_git _gvfg_result _gvfg_git_root)
     # another `project()` call with the new version or manually setting the
     # correct <PROJECT_NAME>_VERSION* variables.
     # set(_gvfg_default_version "${PROJECT_VERSION}")
-    # TODO: Do it this way or just default to "0.1.0"?
     message(DEBUG "Default Project Version: ${_gvfg_default_version}")
 
 
-    # Make sure that Git is available
-    # ZDC: Do we want Git to be required? I implemented an alternative below
-    #      so that Git is not a hard requirement anymore.
+    # Make Git available
     find_package(Git QUIET)
     message(DEBUG "Git_FOUND: ${Git_FOUND}")
 
@@ -57,10 +54,9 @@ function(get_version_from_git _gvfg_result _gvfg_git_root)
     endif()
 
     # Invoke git command to get the tag
-    # ZDC: What happens when I pull the main branch and do this? Does it give
-    #      a commit hash, the latest tag (which is not guaranteed to be the
-    # correct version), or something else?
-    message(DEBUG "_gvfg_git_root: ${_gvfg_git_root}")
+    # TODO: When a branch or commit is pulled (not a specific tag), this
+    #       command still returns the latest tag. Technically, that is not
+    #       the correct version anymore. Determine the best way to handle this.
     execute_process(
         COMMAND "${GIT_EXECUTABLE}" describe --tags --abbrev=0
         WORKING_DIRECTORY "${_gvfg_git_root}"
@@ -71,8 +67,8 @@ function(get_version_from_git _gvfg_result _gvfg_git_root)
 
     # Remove the "v" prefix, since CMake chokes on it
     # TODO: Consider using `if("${_gvfg_version}" MATCHES "<regex>")` for more
-    #       fine-tuned decisions about what processing may be applied to the
-    #       version string from Git.
+    #       fine-tuned, extendable decision-making about what processing may be
+    #       applied to the version string from Git.
     string(REGEX REPLACE "^v" "" _gvfg_version "${_gvfg_version}")
 
     # If git failed to find a version or it is an invalid format, use the

--- a/cmake/get_version_from_git.cmake
+++ b/cmake/get_version_from_git.cmake
@@ -17,26 +17,81 @@ include_guard()
 #[[[
 # Uses Git to determine the version of a git repo.
 #
-# :param gvfg_result: The variable name to assign the result to.
-# :param gvfg_git_root: The directory containing the .git/ directory.
+# :param _gvfg_result: The variable name to assign the result to.
+# :type _gvfg_result: desc*
+# :param _gvfg_git_root: The directory containing the .git/ directory.
+# :type _gvfg_git_root: path
 #
 # .. code-block: cmake
 #
 #    get_version_from_git(MY_PROJECT_VERSION ${CMAKE_CURRENT_SOURCE_DIR})
 #    message("My project's version is: ${MY_PROJECT_VERSION}")
 #]]
-function(get_version_from_git gvfg_result gvfg_git_root)
+function(get_version_from_git _gvfg_result _gvfg_git_root)
+    # Just default the version to "0.1.0"
+    set(_gvfg_default_version "0.1.0")
+    # Alternatively, if there is a project version already set, we could grab
+    # that to use as the default. However, this would require the
+    # get_version_from_git() call to appear after the `project()` call, using
+    # another `project()` call with the new version or manually setting the
+    # correct <PROJECT_NAME>_VERSION* variables.
+    # set(_gvfg_default_version "${PROJECT_VERSION}")
+    # TODO: Do it this way or just default to "0.1.0"?
+    message(DEBUG "Default Project Version: ${_gvfg_default_version}")
+
+
+    # Make sure that Git is available
+    # ZDC: Do we want Git to be required? I implemented an alternative below
+    #      so that Git is not a hard requirement anymore.
     find_package(Git QUIET REQUIRED)
+    message(DEBUG "Git_FOUND: ${Git_FOUND}")
+
+    # If Git was not found, the default project version is returned
+    if(NOT Git_FOUND)
+        message(WARNING
+            "Git installation was not found. Version cannot be acquired "
+            "through this method. Using default version: ${_gvfg_default_version}"
+        )
+        set("${_gvfg_result}" "${_gvfg_default_version}" PARENT_SCOPE)
+        return()
+    endif()
 
     # Invoke git command to get the tag
-    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
-                    WORKING_DIRECTORY ${gvfg_git_root}
-                    OUTPUT_VARIABLE gvfg_version
-                    OUTPUT_STRIP_TRAILING_WHITESPACE
+    # ZDC: What happens when I pull the main branch and do this? Does it give
+    #      a commit hash, the latest tag (which is not guaranteed to be the
+    # correct version), or something else?
+    message(DEBUG "_gvfg_git_root: ${_gvfg_git_root}")
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --abbrev=0
+        WORKING_DIRECTORY "${_gvfg_git_root}"
+        OUTPUT_VARIABLE _gvfg_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    message(DEBUG "Git version tag found: ${_gvfg_version}")
 
     # Remove the "v" prefix, since CMake chokes on it
-    STRING(REGEX REPLACE "^v" "" gvfg_version ${gvfg_version})
+    # Issue: ${_gvfg_version} needed to be in double quotes, which is generally
+    #        what should be done in all cases unless you have a *very* good
+    #        reason to do otherwise (some instances of dereferencing lists is
+    #        the only time I can think of). It is possible for _gvfg_version to be
+    #        empty, which causes string(REGEX REPLACE to throw an error about
+    #        not getting enough arguments. Setting  _gvfg_version to an empty
+    #        string before running `execute_process()` surprisingly does not
+    #        mitigate the issue.
+    # TODO: Consider using `if("${_gvfg_version}" MATCHES "<regex>")` for more
+    #       fine-tuned decisions about what processing may be applied to the
+    #       version string from Git.
+    string(REGEX REPLACE "^v" "" _gvfg_version "${_gvfg_version}")
 
-    set(${gvfg_result} ${gvfg_version} PARENT_SCOPE)
+    # If git failed to find a version or it is an invalid format, use the
+    # default version
+    if(NOT "${_gvfg_version}" MATCHES "^([0-9]+(\.[0-9]+(\.[0-9]+(\.[0-9]+)?)?)?)$")
+        message(WARNING
+            "Git returned an invalid version tag of \"${_gvfg_version}\".\n"
+            "Defaulting to version: ${_gvfg_default_version}\n"
+        )
+        set(_gvfg_version "${_gvfg_default_version}")
+    endif()
+
+    set("${_gvfg_result}" "${_gvfg_version}" PARENT_SCOPE)
 endfunction()

--- a/cmake/get_version_from_git.cmake
+++ b/cmake/get_version_from_git.cmake
@@ -43,7 +43,7 @@ function(get_version_from_git _gvfg_result _gvfg_git_root)
     # Make sure that Git is available
     # ZDC: Do we want Git to be required? I implemented an alternative below
     #      so that Git is not a hard requirement anymore.
-    find_package(Git QUIET REQUIRED)
+    find_package(Git QUIET)
     message(DEBUG "Git_FOUND: ${Git_FOUND}")
 
     # If Git was not found, the default project version is returned
@@ -70,14 +70,6 @@ function(get_version_from_git _gvfg_result _gvfg_git_root)
     message(DEBUG "Git version tag found: ${_gvfg_version}")
 
     # Remove the "v" prefix, since CMake chokes on it
-    # Issue: ${_gvfg_version} needed to be in double quotes, which is generally
-    #        what should be done in all cases unless you have a *very* good
-    #        reason to do otherwise (some instances of dereferencing lists is
-    #        the only time I can think of). It is possible for _gvfg_version to be
-    #        empty, which causes string(REGEX REPLACE to throw an error about
-    #        not getting enough arguments. Setting  _gvfg_version to an empty
-    #        string before running `execute_process()` surprisingly does not
-    #        mitigate the issue.
     # TODO: Consider using `if("${_gvfg_version}" MATCHES "<regex>")` for more
     #       fine-tuned decisions about what processing may be applied to the
     #       version string from Git.


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**

If an NWChemEx package is downloaded through any method other than `git clone` that does not retain the Git repository (`.git/`), `get_version_from_git()` from `NWXCMake/cmake/get_version_from_git.cmake` will fail.

**Fixing the Crash**

The reason that `get_version_from_git()` fails is that [L32](https://github.com/NWChemEx/NWXCMake/blob/master/cmake/get_version_from_git.cmake#L32) invokes the `execute_process()` function to call Git, but the output version is not guaranteed to be assigned a value (it may not even be guaranteed to get defined). When the output version is empty/undefined, `string(REPLACE` on [L39](https://github.com/NWChemEx/NWXCMake/blob/master/cmake/get_version_from_git.cmake#L39) fails because CMake thinks that the call is not getting enough arguments anymore.

This is a quick fix, although it took some time to debug what was wrong. I just added double quotes around all variable dereferences in the function to ensure that, at a minimum, an empty string is passed to the function. Surrounding variable dereferences is good practice in CMake, except in a few instances like dereferencing lists sometimes. My rule of thumb is to always add double quotes unless I am dealing with lists or I get an error, then consider removing the quotes to fix it.

This introduced another issue where an empty version might be returned, which also makes the build fail since it is not in CMake's version format of `MAJOR.MINOR.PATCH.TWEAK`. I introduced a default version (0.1.0) to `get_version_from_git()` that will be returned if an invalid version is received from the Git command. The small tweak that removes the potential `v` prepended on a version tag was retained, though, so supported version formats are `0.0.0.0` and `v0.0.0.0`, where all but the major version number are optional.

**Removing the Hard Git Requirement**

Currently, [L29](https://github.com/NWChemEx/NWXCMake/blob/master/cmake/get_version_from_git.cmake#L29) calls `find_package()` with the `REQUIRED` keyword. This means that if Git is not installed on the system, the build will also fail. I removed `REQUIRED` and added a check for whether Git was found or not, returning early with the default version if Git is not found.

**TODOs/Questions**

- [ ] Do we want to retain some of the `message(DEBUG` output that I added that reports the values of various variables related to `get_version_from_git()`? I think they would be very useful if something starts going wrong, or just to make sure that the correct versions are actually being grabbed.
- [ ] Decide to resolve or punt on the `# TODO:` comments I added in `NWXCMake/cmake/get_version_from_git.cmake`.
- [ ] I didn't see a `bump:patch` tag that I could assign to this PR. Is that because it is the automatic version increment? I did see `bump:minor` and `bump:major`, but I wouldn't call this a new feature and certainly hope I didn't introduce API-breaking changes.
